### PR TITLE
[WIP]ChatSpacenoデータベースの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,45 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+# データベース設計
+
+## users
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+has_many :messeages
+has_many :groups, through: :users_groups
+
+
+## groups
+|Column|Type|Options|
+|------|----|-------|
+|team|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+has_many :users, through: :users_groups
+has_many :comments
+
+## users_groups
+|Column|Type|Options|
+|------|----|-------|
+|users_id|integer|null: false, foreign_key: true|
+|groups_id|integer|null: false, foreign_key: true|
+
+
+## messages
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|string|
+|date|datetime|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+belongs_to :user
+belongs_to :group

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Things you may want to cover:
 |password|string|null: false|
 ### Association
 has_many :messeages
-has_many :groups, through: :users_groups
-
+has_many :groups, through: :authorizations
+has_many :authorizations
 
 ## groups
 |Column|Type|Options|
@@ -43,15 +43,18 @@ has_many :groups, through: :users_groups
 |team|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
-has_many :users, through: :users_groups
+has_many :users, through: :authorizations
+has_many :authorizations
 has_many :comments
 
-## users_groups
+## authorizations
 |Column|Type|Options|
 |------|----|-------|
 |users_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false, foreign_key: true|
-
+### Association
+belongs_to :user
+belongs_to :group
 
 ## messages
 |Column|Type|Options|


### PR DESCRIPTION
# What
ChatSpaceのデータベースに、usersテーブル、groupsテーブル、users_groupsテーブル、messageテーブルを作成しました。それぞれのテーブルのカラムは以下の通りです。
・users (name:  email:   password:)

・groups (team:  user_id:  contents_id)

・users_groups (users_id:  groups_id:)

・messages (text:  image: date:  user_id:  group_id:)

# Why
ChatSpaceのデータはユーザー、グループ、メッセージの３つが新規で登録されるからです。
usersでは新規登録の際に名前、メールアドレス、パスワードも登録するため。
groupsでは、既存のユーザー達が登録されるため。
messageでは、文章と画像を投稿し、いつ投稿したかも表示できるようにするため。
usersとgroupsは多対多の関係であるので、中間テーブルも加えました。